### PR TITLE
Convert unix time to seconds from milliseconds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ Wootric.prototype.identify = function(identify) {
   var createdAt = identify.created();
   var language = traits.language;
 
-  if (createdAt && createdAt.getTime) window.wootricSettings.created_at = createdAt.getTime();
+  if (createdAt && createdAt.getTime) window.wootricSettings.created_at = createdAt.getTime() / 1000;
   if (language) window.wootricSettings.language = language;
   window.wootricSettings.email = email;
   // Set the rest of the traits as properties


### PR DESCRIPTION
As requested by Jessica Pfeifer at Wootric, we are changing the created_at timestamp format from unix milliseconds to unix seconds. 

This change is in line with Wootric docs which indicate that the created_at timestamp should be in unix seconds. Ref: http://docs.wootric.com/install/#full-example

Original request from Wootric:

> When given a created_at parameter in seconds, Segment casts it to mili seconds then creates a Date object and finally calls getTime on that object. getTime returns mili seconds to our WootricSettings, this causes Warnings and data inconsistency.
> Is there a reason why segment needs to change the original parameter?
> How can we maintain the integrity of the parameter in seconds to ensure that customer data reaches us correctly?
