### PR TITLE
Convert date type properties to Wootric format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.0.2 / 2017-02-02
+==================
+
+  * Update date properties to be in Unix timestamp format and suffixed with '_date'
+
 2.0.1 / 2016-10-06
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,8 @@
  * Module dependencies.
  */
 
+var foldl = require('@ndhoule/foldl');
+var is = require('is');
 var integration = require('@segment/analytics.js-integration');
 var omit = require('omit');
 
@@ -64,11 +66,18 @@ Wootric.prototype.identify = function(identify) {
   var createdAt = identify.created();
   var language = traits.language;
 
-  if (createdAt && createdAt.getTime) window.wootricSettings.created_at = Math.round(createdAt.getTime() / 1000);
+  if (createdAt && createdAt.getTime) window.wootricSettings.created_at = convertDate(createdAt);
   if (language) window.wootricSettings.language = language;
   window.wootricSettings.email = email;
+
+  // Convert keys to Wootric format
+  var newTraits = foldl(function(results, value, key) {
+    results[convertKey(key, value)] = is.date(value) ? convertDate(value) : value;
+    return results;
+  }, {}, traits);
+
   // Set the rest of the traits as properties
-  window.wootricSettings.properties = omit(['created', 'createdAt', 'email'], traits);
+  window.wootricSettings.properties = omit(['created', 'createdAt', 'email'], newTraits);
 
   window.wootric('run');
 };
@@ -98,3 +107,39 @@ Wootric.prototype.page = function(page) {
     cacheBuster: Math.random()
   });
 };
+
+/**
+* Convert trait key to Wootric format.
+*
+* @param {string} trait
+* @param {*} value
+*/
+
+function convertKey(key, value) {
+  if (is.date(value) && !key.endsWith('_date')) return key + '_date';
+  return key;
+}
+
+/**
+ * Convert a date to unix timestamp.
+ *
+ * @api private
+ * @param {Date} date
+ * @return {number}
+ */
+
+function convertDate(date) {
+  return Math.round(date.getTime() / 1000);
+}
+
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+    var subjectString = this.toString();
+    if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.lastIndexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-wootric",
   "description": "The Wootric analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-wootric#readme",
   "dependencies": {
+    "@ndhoule/foldl": "^2.0.1",
     "@segment/analytics.js-integration": "^2.1.0",
     "is": "^3.1.0",
     "omit": "harrietgrace/omit"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -144,6 +144,31 @@ describe('Wootric', function() {
         analytics.assert(window.wootricSettings.properties.property2 === 'bar');
       });
 
+      it('should set suffix _date to property key and convert date if trait is a date', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: '2015-01-01'
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.assert(window.wootricSettings.properties.hasOwnProperty('property2_date'));
+        analytics.assert(!window.wootricSettings.properties.hasOwnProperty('property2'));
+        analytics.equal(window.wootricSettings.properties.property2_date, 1420070400);
+      });
+
+      it('should not convert to date if property key has suffix _date', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2_date: 1420070400
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.equal(window.wootricSettings.properties.property2_date, 1420070400);
+        analytics.assert(!window.wootricSettings.properties.hasOwnProperty('property2_date_date'));
+      });
+
       it('should omit email and createdAt when setting window.wootricSettings.properties', function() {
         analytics.identify({
           email: 'shawn@shawnmorgan.com',


### PR DESCRIPTION
Wootric needs date properties to be in Unix timestamp format
and suffixed with '_date'.

Docs: http://docs.wootric.com/javascript/#setting-up-custom-attributes