### PR TITLE
[PLATFORM-2919] Using the latest Wootric CDN URL instead of CloudFront domain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var Wootric = module.exports = integration('Wootric')
   .global('wootricSettings')
   .global('wootric_survey_immediately')
   .global('wootric')
-  .tag('library', '<script src="//disutgh7q0ncc.cloudfront.net/beacon.js"></script>')
+  .tag('library', '<script src="//cdn.wootric.com/wootric-sdk.js"></script>')
   .tag('pixel', '<img src="//d8myem934l1zi.cloudfront.net/pixel.gif?account_token={{ accountToken }}&email={{ email }}&created_at={{ createdAt }}&url={{ url }}&random={{ cacheBuster }}">');
 
 /**


### PR DESCRIPTION
Hello,

Following the changes in Wootric guidelines: https://gist.github.com/marinhero/0b7dc607a5644d4ec634baf0799218d3 the script URL is now hosted on Wootric's own CDN instead of a rotating CloudFront domain.

This change is needed for websites with restrictive CSP policies.

### Changes
- Domain change for the injected script tag